### PR TITLE
mock/poc: data collection to adobe analytics + enrich recs strategy data collection

### DIFF
--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -1,3 +1,6 @@
+// TODO move this to top level
+import { initializeMSEWithStorefrontInstance } from '../../scripts/mse-utils.js';
+
 import {
   Component, Fragment, h, render,
 } from '../../scripts/preact.js';
@@ -97,10 +100,30 @@ class ProductDetailPage extends Component {
   }
 
   async componentDidMount() {
+    // todo move this to top level
+    await initializeMSEWithStorefrontInstance();
+
     const product = await getProduct(getSkuFromUrl());
 
     if (!product) {
       errorGettingProduct();
+    }
+
+    if (window.magentoStorefrontEvents) {
+      const productCtx = {
+        name: product.name,
+        productId: product.id,
+        sku: product.sku,
+        pricing: {
+          regularPrice: product.priceRange?.maximum?.final.amount.value,
+          minimalPrice: product.priceRange?.maximum?.regular.amount.value,
+          maximalPrice: product.priceRange?.minimum?.regular.amount.value,
+          currencyCode: product.priceRange?.maximum?.final.amount.value,
+        },
+        // TODO add product image url + selected options
+      };
+      window.magentoStorefrontEvents.context.setProduct(productCtx);
+      window.magentoStorefrontEvents.publish.productPageView();
     }
 
     const selection = {
@@ -133,6 +156,7 @@ class ProductDetailPage extends Component {
   }
 
   onAddToCart = async () => {
+    // TODO set cart context and generate cart event
     if (Object.keys(this.state.selection).length === this.state.product.options.length) {
       const optionsUIDs = Object.values(this.state.selection).map((option) => option.id);
       console.log({

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "wtr \"./test/**/*.test.js\" --node-resolve --port=2000 --coverage",
     "test:watch": "npm test -- --watch",
     "lint:js": "eslint .",
+    "lint:fix": "eslint --fix .",
     "lint:css": "stylelint 'blocks/**/*.css' 'styles/*.css'",
     "lint": "npm run lint:js && npm run lint:css",
     "start": "hlx up --print-index",

--- a/scripts/mse-utils.js
+++ b/scripts/mse-utils.js
@@ -1,4 +1,3 @@
-import './commerce-events-sdk.js';
 import { performMonolithGraphQLQuery } from './commerce.js';
 
 const STOREFRONT_QUERY_RESULT_KEY = 'storefront-query-result';
@@ -27,7 +26,22 @@ const STOREFRONT_CONTEXT_QUERY = `
     }
 `;
 
-const eventsSDKInitialized = false;
+function loadScript(url) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.addEventListener('load', () => {
+      resolve();
+    });
+    script.addEventListener('error', () => {
+      reject(new Error(`Failed to load script ${url}`));
+    });
+    document.head.appendChild(script);
+  });
+}
+
+let eventsSDKInitialized = false;
+
 export async function initializeMSEWithStorefrontInstance() {
   if (!eventsSDKInitialized) {
     let result;
@@ -42,43 +56,73 @@ export async function initializeMSEWithStorefrontInstance() {
       throw new Error('error fetching storefront context');
     }
 
-    const {
-      environment,
-      environment_id: environmentId,
-      website_id: websiteId,
-      website_code: websiteCode,
-      website_name: websiteName,
-      store_url: storeUrl,
-      store_id: storeId,
-      store_code: storeCode,
-      store_name: storeName,
-      store_view_id: storeViewId,
-      store_view_code: storeViewCode,
-      store_view_name: storeViewName,
-      catalog_extension_version: catalogExtensionVersion,
-    } = result.dataServicesStorefrontInstanceContext;
-    const { base_currency_code: baseCurrencyCode } = result.storeConfig;
+    try {
+      if (!eventsSDKInitialized) {
+        await Promise.all([
+          // sdk - publishes to acdl
+          // TODO remove this script, load acdl instead, and publish to acdl directly
+          loadScript('https://unpkg.com/@adobe/magento-storefront-events-sdk/dist/index.js'),
+          // collector - acdl sub, forwards to edges
+          loadScript('https://unpkg.com/@adobe/magento-storefront-event-collector/dist/index.js'),
+        ]);
+        eventsSDKInitialized = true;
 
-    const context = {
-      environmentId,
-      environment,
-      storeUrl,
-      websiteId,
-      websiteCode,
-      storeId,
-      storeCode,
-      storeViewId,
-      storeViewCode,
-      websiteName,
-      storeName,
-      storeViewName,
-      baseCurrencyCode,
-      storeViewCurrencyCode: baseCurrencyCode,
-      catalogExtensionVersion,
-    };
+        const {
+          environment,
+          environment_id: environmentId,
+          website_id: websiteId,
+          website_code: websiteCode,
+          website_name: websiteName,
+          store_url: storeUrl,
+          store_id: storeId,
+          store_code: storeCode,
+          store_name: storeName,
+          store_view_id: storeViewId,
+          store_view_code: storeViewCode,
+          store_view_name: storeViewName,
+          catalog_extension_version: catalogExtensionVersion,
+        } = result.dataServicesStorefrontInstanceContext;
+        const { base_currency_code: baseCurrencyCode } = result.storeConfig;
 
-    if (window.magentoStorefrontEvents) {
-      window.magentoStorefrontEvents.context.setStorefrontInstance(context);
+        // required for all data collection
+        const strorefrontInstanceContext = {
+          environmentId,
+          environment,
+          storeUrl,
+          websiteId,
+          websiteCode,
+          storeId,
+          storeCode,
+          storeViewId,
+          storeViewCode,
+          websiteName,
+          storeName,
+          storeViewName,
+          baseCurrencyCode,
+          storeViewCurrencyCode: baseCurrencyCode,
+          catalogExtensionVersion,
+        };
+
+        // required for AEP/Adobe Analytics
+        // TODO: get these values from beacon extension graphql api
+        const aepContext = {
+          imsOrgId: '53A16ACB5CC1D3760A495C99@AdobeOrg',
+          datastreamId: '4d8ccd3b-9463-43bf-862a-c908fad3b20b',
+        };
+        const eventForwardingContext = {
+          aep: true,
+          snowplow: true,
+        };
+
+        if (window.magentoStorefrontEvents) {
+          window.magentoStorefrontEvents.context.setStorefrontInstance(strorefrontInstanceContext);
+          window.magentoStorefrontEvents.context.setAEP(aepContext);
+          window.magentoStorefrontEvents.context.setEventForwarding(eventForwardingContext);
+          window.magentoStorefrontEvents.publish.pageView();
+        }
+      }
+    } catch (error) {
+      console.error(`failed to initialize mse: ${error}`);
     }
   }
 }


### PR DESCRIPTION
changes:

(1) load mse collector :we had the event sdk (publisher to acdl) but not the event collector; the sdk pushes events to the data layer but in order for them to be sent to commerce (for imerch evaluation) or AEP, the collector script has to be in place. details on these scripts + diagram [here](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=EntComm&title=Unified+Storefront+Data+Collection#UnifiedStorefrontDataCollection-Eventsoverview)

(2) load sdk and collector from unpkg (has latest release) as opposed to storing the script in repo - @herzog31 did you have a specific reason for having the sdk js in the scripts directory?

(3) initialize data collection for adobe experience cloud/analytics - see screenshots of maidenform data in AEP and AA

<img width="1577" alt="Screenshot 2023-04-05 at 14 46 31" src="https://user-images.githubusercontent.com/847621/230192294-7302ce0f-dacb-4751-adf4-05ba3725c533.png">

<img width="1485" alt="Screenshot 2023-04-05 at 14 42 12" src="https://user-images.githubusercontent.com/847621/230192313-b8dc72fb-00c8-4e39-a544-7a1873ae8b11.png">

